### PR TITLE
Fix returning custom error pointer as error

### DIFF
--- a/poeditor/client.go
+++ b/poeditor/client.go
@@ -79,7 +79,6 @@ func (c *Client) GetProjectLanguages(projectID string) ([]Language, error) {
 
 	params := map[string]string{"id": projectID}
 	err := c.request("/languages/list", params, &resp)
-	//lint:ignore SA4023 false-positive https://github.com/dominikh/go-tools/issues/1194
 	if err := handleRequestErr(err, resp.baseResponse); err != nil {
 		return nil, err
 	}
@@ -104,7 +103,6 @@ func (c *Client) GetExportURL(projectID, languageCode string) (string, error) {
 		"type":     "json",
 	}
 	err := c.request("/projects/export", params, &resp)
-	//lint:ignore SA4023 false-positive https://github.com/dominikh/go-tools/issues/1194
 	if err := handleRequestErr(err, resp.baseResponse); err != nil {
 		return "", err
 	}

--- a/poeditor/error.go
+++ b/poeditor/error.go
@@ -14,7 +14,7 @@ type Error struct {
 	Description string
 }
 
-func TryNewErrorFromResponse(resp response) *Error {
+func TryNewErrorFromResponse(resp response) error {
 	code, _ := strconv.Atoi(resp.Code)
 
 	if code == 200 {


### PR DESCRIPTION
```
panic: value method github.com/leancodepl/poe2arb/poeditor.Error.Error called using nil *Error pointer

goroutine 1 [running]:
github.com/leancodepl/poe2arb/poeditor.(*Error).Error(0x0)
        <autogenerated>:1 +0x84
github.com/spf13/cobra.(*Command).ExecuteC(0x102e3e3a0)
        /Users/albert/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:986 +0x49c
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/albert/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
github.com/leancodepl/poe2arb/cmd.Execute()
        /Users/albert/Projects/LeanCode/poe2arb/cmd/poe2arb.go:15 +0xa8
main.main()
        /Users/albert/Projects/LeanCode/poe2arb/main.go:6 +0x20
```