### PR TITLE
Add non-zero error code on error

### DIFF
--- a/cmd/poe.go
+++ b/cmd/poe.go
@@ -45,7 +45,7 @@ func runPoe(cmd *cobra.Command, args []string) error {
 
 	sel, err := getOptionsSelector(cmd)
 	if err != nil {
-		logSub.Error("failed " + err.Error())
+		logSub.Error("failed: " + err.Error())
 		return err
 	}
 

--- a/cmd/poe2arb.go
+++ b/cmd/poe2arb.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/leancodepl/poe2arb/log"
 	"github.com/spf13/cobra"
@@ -24,7 +25,9 @@ func Execute(logger *log.Logger) {
 
 	ctx := context.WithValue(context.Background(), loggerKey, logger)
 
-	rootCmd.ExecuteContext(ctx)
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		os.Exit(1)
+	}
 }
 
 func getLogger(cmd *cobra.Command) *log.Logger {


### PR DESCRIPTION
```
➜  poe2arb git:(fix/60-error-code) go install .
➜  poe2arb git:(fix/60-error-code) poe2arb poe
 • loading options
   • failed: no pubspec.yaml found in the current or any parent directory
➜  poe2arb git:(fix/60-error-code) print $?
1
➜  poe2arb git:(fix/60-error-code) 
```

Fixes #60.