### PR TITLE
Automatically add shell completion files when `brew install`-ed

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,3 +23,6 @@ brews:
     folder: Formula
     homepage: "https://github.com/leancodepl/poe2arb"
     description: "POEditor JSON to Flutter ARB converter."
+    install: |
+      bin.install "poe2arb"
+      generate_completions_from_executable(bin/"poe2arb", "completion")

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,5 @@
 builds:
-  -
-    targets:
+  - targets:
       - linux_amd64
       - windows_amd64
       - darwin_amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,8 +21,8 @@ brews:
       owner: leancodepl
       name: poe2arb
     folder: Formula
-    homepage: "https://github.com/leancodepl/poe2arb"
-    description: "POEditor JSON to Flutter ARB converter."
+    homepage: https://github.com/leancodepl/poe2arb
+    description: POEditor JSON to Flutter ARB converter.
     install: |
       bin.install "poe2arb"
       generate_completions_from_executable(bin/"poe2arb", "completion")

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ changelog:
   use: github-native
 release:
 brews:
-  - tap:
+  - repository:
       owner: leancodepl
       name: poe2arb
     folder: Formula


### PR DESCRIPTION
Examples:
- [arduino-cli](https://github.com/Homebrew/homebrew-core/blob/c0865a1930218a8668bc207837f28831254be622/Formula/a/arduino-cli.rb#L36)
- [gh](https://github.com/Homebrew/homebrew-core/blob/c0865a1930218a8668bc207837f28831254be622/Formula/gh.rb#L36)
- [emu](https://github.com/bartekpacia/emu/blob/master/.goreleaser.yaml#L41)

See also:
- [`generate_completions_from_executable`](https://rubydoc.brew.sh/Formula.html#generate_completions_from_executable-instance_method)

### Usage example

The user of Homebrew has to do one thing to make shell completions (from all formulaes they install) available – add the following code to e.g. `~/.zshrc`:

```bash
if command -v brew >/dev/null 2>&1; then
	# Set up completions for `brew` command and `brew`-installed programs
	# See: https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh
	FPATH="$(brew --prefix)/share/zsh/site-functions:$FPATH"
fi
```